### PR TITLE
Fix extension regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = uglifyify
 function uglifyify(file) {
   var buffer = ''
 
-  if (!/\.js$|\.coffee$|\.eco|\.hbs$/.test(file)) return through()
+  if (!/(\.js|\.coffee|\.eco|\.hbs)$/.test(file)) return through()
 
   return through(function write(chunk) {
     buffer += chunk


### PR DESCRIPTION
So it no longer matches `.eco` in the middle of the filename.

Sorry for that, it was an unfortunate oversight.
