### PR TITLE
Preserve incoming source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,22 +1,45 @@
 var through = require('through')
   , ujs = require('uglify-js')
+  , convert = require('convert-source-map')
 
 module.exports = uglifyify
 function uglifyify(file) {
-  var buffer = ''
+  var buffer = '', match, inSourceMap = null
 
   if (!/\.js$|\.coffee$|\.eco|\.hbs$/.test(file)) return through()
 
   return through(function write(chunk) {
     buffer += chunk
   }, function ready() {
-    buffer = ujs.minify(buffer, {
-        fromString: true
-      , compress: true
-      , mangle: true
-    })
+    // Check if incoming source code already has source map comment.
+    // If so, send it in to ujs.minify as the inSourceMap parameter
+    match = buffer.match(/\/\/[#@] sourceMappingURL=data:application\/json;base64,([a-zA-Z0-9+/]+)={0,2}$/)
+    if (match) {
+      inSourceMap = convert.fromJSON(Buffer(match[1], 'base64').toString())['sourcemap']
 
-    this.queue(buffer.code)
-    this.queue(null)
+      buffer = ujs.minify(buffer, {
+          fromString: true
+        , compress: true
+        , mangle: true
+        , inSourceMap: inSourceMap
+        , outSourceMap: 'out.js.map'
+      })
+
+      var map = convert.fromJSON(buffer.map)
+      map.setProperty('sources', [file])
+      map.setProperty('sourcesContent', inSourceMap.sourcesContent)
+
+      this.queue(buffer.code + '\n' + map.toComment())
+      this.queue(null)
+    } else {
+      buffer = ujs.minify(buffer, {
+          fromString: true
+        , compress: true
+        , mangle: true
+      })
+
+      this.queue(buffer.code)
+      this.queue(null)
+    }
   })
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "dependencies": {
     "uglify-js": "2.x.x",
-    "through": "~2.3.4"
+    "through": "~2.3.4",
+    "convert-source-map": "~0.2.3"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
When I supplied `transform: ['coffeeify', 'uglifyify']` to grunt-browserify, the CoffeeScript-to-JavaScript source maps that coffeeify produces got lost, because uglifyify ignored them.  With this patch, uglifyify is now aware when incoming source code contains an existing source map and passes it through to uglify-js, so that errors in the uglified-browsified-compiled JS can map back directly to their CoffeeScript source code.
