### PR TITLE
Add support for .jsx files

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = uglifyify
 function uglifyify(file) {
   var buffer = ''
 
-  if (!/(?:\.js|\.coffee|\.eco|\.hbs)$/.test(file)) return through()
+  if (!/(?:\.js|\.coffee|\.eco|\.hbs|\.jsx)$/.test(file)) return through()
 
   return through(function write(chunk) {
     buffer += chunk


### PR DESCRIPTION
This adds support for uglifying `.jsx` files, which are transformed to regular JavaScript using [reactify](https://www.npmjs.org/package/reactify)

I noticed that there have been many patches to add extensions to this regex. Could the test be more liberal? Perhaps `extension !== ".json"`? This seems to work for my use case. I would be happy to send a patch if you think this would work.
