### PR TITLE
Add support for optional second parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,13 @@
 var convert = require('convert-source-map')
   , through = require('through')
+  , path = require('path')
   , ujs = require('uglify-js')
 
 module.exports = uglifyify
-function uglifyify(file) {
+function uglifyify(file, opts) {
   var buffer = ''
 
-  if (/\.json$/.test(file)) return through()
+  if (/\.json$/.test(file) || opts && opts.exts && opts.exts.indexOf(path.extname(file)) === -1) return through()
 
   return through(function write(chunk) {
     buffer += chunk


### PR DESCRIPTION
Hi @hughsk,

First off, thanks for putting this module together.

This PR adds support for an optional second parameter to be used for additional options. Specifically, the additional option we need is the ability to specify the file extensions to which this transform should be applied. We are hoping to use this transform in combination with [parcelify](https://github.com/rotundasoftware/parcelify) which deals with css assets as well as js assets so we need to only apply this transform to the js assets.

Please let me know what you think!

PS - This change does not break the current API.
