### PR TITLE
Pass through options to uglify

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var convert = require('convert-source-map')
   , through = require('through')
   , path = require('path')
   , ujs = require('uglify-js')
+  , extend = require('extend')
 
 module.exports = uglifyify
 function uglifyify(file, opts) {
@@ -23,11 +24,11 @@ function uglifyify(file, opts) {
   return through(function write(chunk) {
     buffer += chunk
   }, capture(function ready() {
-    var opts = {
+    opts = extend({}, {
       fromString: true
       , compress: true
       , mangle: true
-    }
+    }, opts)
 
     // Check if incoming source code already has source map comment.
     // If so, send it in to ujs.minify as the inSourceMap parameter

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "uglify-js": "2.x.x",
     "through": "~2.3.4",
-    "convert-source-map": "~0.2.3"
+    "convert-source-map": "~0.2.3",
+    "extend": "^1.2.1"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Pass through options to uglify so that default options can be overridden. This is mainly so we can set `mangle: false` so that uglify doesn't break our build for IE8 (https://github.com/mishoo/UglifyJS2/issues/248)
