### PR TITLE
Make source map truly conditional

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,15 +42,17 @@ function uglifyify(file, opts) {
       /\/\/[#@] ?sourceMappingURL=data:application\/json;base64,([a-zA-Z0-9+\/]+)={0,2}$/
     )
 
-    opts.outSourceMap = 'out.js.map'
-    opts.inSourceMap = sourceMaps && convert.fromJSON(
-      new Buffer(sourceMaps[1], 'base64').toString()
-    ).sourcemap
+    if(sourceMaps) {
+      opts.outSourceMap = 'out.js.map'
+      opts.inSourceMap = sourceMaps && convert.fromJSON(
+        new Buffer(sourceMaps[1], 'base64').toString()
+      ).sourcemap
+    }
 
     var min = ujs.minify(buffer, opts)
     this.queue(min.code)
 
-    if (min.map) {
+    if (sourceMaps) {
       var map = convert.fromJSON(min.map)
       map.setProperty('sources', [file])
       map.setProperty('sourcesContent', sourceMaps


### PR DESCRIPTION
Currently source map comments are always present in the minified file because
1. sourceMap options are always set regardless of the value of `sourceMaps`
2. `min.map` always returns true because of this `toString` business going on here: https://github.com/mishoo/UglifyJS2/blob/1a34a13e3393a9afd6a032b5c2bf3e29cbdfe153/tools/node.js#L136

This fixes #12
