### PR TITLE
Make source map regex support trailing newlines

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function uglifyify(file, opts) {
     // Check if incoming source code already has source map comment.
     // If so, send it in to ujs.minify as the inSourceMap parameter
     var sourceMaps = buffer.match(
-      /\/\/[#@] ?sourceMappingURL=data:application\/json;base64,([a-zA-Z0-9+\/]+)={0,2}$/
+      /\/\/[#@] ?sourceMappingURL=data:application\/json;base64,([a-zA-Z0-9+\/]+)={0,2}\n?$/
     )
 
     if(sourceMaps) {


### PR DESCRIPTION
Transforms like coffeeify add a trailing newline to source maps.
(https://github.com/jnordberg/coffeeify/blob/deae403ff6807b741d51f0ed8c0b4015a9d95986/index.js#L67)