### PR TITLE
Adding a way to disable sourcemaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,19 +34,23 @@ function uglifyify(file, opts) {
       fromString: true
       , compress: true
       , mangle: true
+      , sourceMaps: true
     }, opts)
 
-    // Check if incoming source code already has source map comment.
-    // If so, send it in to ujs.minify as the inSourceMap parameter
-    var sourceMaps = buffer.match(
-      /\/\/[#@] ?sourceMappingURL=data:application\/json;base64,([a-zA-Z0-9+\/]+)={0,2}$/
-    )
+    if(opts.sourceMaps) {
+      // Check if incoming source code already has source map comment.
+      // If so, send it in to ujs.minify as the inSourceMap parameter
+      var sourceMaps = buffer.match(
+        /\/\/[#@] ?sourceMappingURL=data:application\/json;base64,([a-zA-Z0-9+\/]+)={0,2}$/
+      )
 
-    if(sourceMaps) {
-      opts.outSourceMap = 'out.js.map'
-      opts.inSourceMap = sourceMaps && convert.fromJSON(
-        new Buffer(sourceMaps[1], 'base64').toString()
-      ).sourcemap
+
+      if(sourceMaps) {
+        opts.outSourceMap = 'out.js.map'
+        opts.inSourceMap = sourceMaps && convert.fromJSON(
+          new Buffer(sourceMaps[1], 'base64').toString()
+        ).sourcemap
+      }
     }
 
     var min = ujs.minify(buffer, opts)


### PR DESCRIPTION
In the previous way, if any of the sub files were with source maps, the entire output would include source maps, if you wanted to disable source maps, you had not way.

This adds the sourceMaps boolean option, that either enables or disables source maps, 