### PR TITLE
Pass filename to uglify-js

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ function uglifyify(file, opts) {
       fromString: true
       , compress: true
       , mangle: true
+      , filename: file
     }, opts)
 
     // Check if incoming source code already has source map comment.


### PR DESCRIPTION
I had a problem with Uglifyify that some errors didn't have correct file names visible -- but there still was line, column and position there and it was really hard to find where was the real problem.

I've fixed the problem by passing on `file` as `options.filename` to uglify-js.

However in order for this actually work uglify-js needs pull request mishoo/UglifyJS2#562 accepted.