### PR TITLE
deps: bump browserify version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "bl": "^0.9.3",
-    "browserify": "^8.1.1",
+    "browserify": "^10.1.3",
     "from2": "^1.3.0",
     "tap-spec": "^2.1.2",
     "tape": "^3.2.0",


### PR DESCRIPTION
If https://github.com/hughsk/uglifyify/issues/33#issuecomment-100977660 is indeed a browserify bug, at least we're testing against the latest version. Thanks!
## Changes
- **deps**: bump browserify version to latest
