### PR TITLE
1. modify sourceMap regExp  2.dont't edit source map

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function uglifyify(file, opts) {
     buffer += chunk
   }, capture(function ready() {
     var matched = buffer.match(
-      /\/\/[#@] ?sourceMappingURL=data:application\/json;base64,([a-zA-Z0-9+\/]+)={0,2}\n?$/
+      /\/\/[#@] ?sourceMappingURL=data:application\/json;.*;base64,([a-zA-Z0-9+\/]+)={0,2}\n?$/
     )
 
     debug = opts.sourcemap !== false && (debug || matched)
@@ -75,16 +75,8 @@ function uglifyify(file, opts) {
     this.queue(min.code)
 
     if (min.map && min.map !== 'null') {
-      var map = convert.fromJSON(min.map)
-
-      map.setProperty('sources', [file])
-      map.setProperty('sourcesContent', matched
-        ? opts.inSourceMap.sourcesContent
-        : [buffer]
-      )
-
       this.queue('\n')
-      this.queue(map.toComment())
+      this.queue(convert.fromJSON(min.map).toComment())
     }
 
     this.queue(null)

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function uglifyify(file, opts) {
     buffer += chunk
   }, capture(function ready() {
     var matched = buffer.match(
-      /\/\/[#@] ?sourceMappingURL=data:application\/json;.*;base64,([a-zA-Z0-9+\/]+)={0,2}\n?$/
+      /\/\/[#@] ?sourceMappingURL=data:application\/json.*;base64,([a-zA-Z0-9+\/]+)={0,2}\n?$/
     )
 
     debug = opts.sourcemap !== false && (debug || matched)


### PR DESCRIPTION
1. some times sourceMapUrl have a charset field
2. do not need to modify generated sourceMap

When I use uglifyify writing a browserify plugin.
It do not work.

```
function createRevStream(dest, revdest, debug) {
  var min = uglifyify(dest, { sourcemap: true }).pipe(exorcist(dest + '.map'));
  var out = fs.createWriteStream(revdest)
  var s = through(function write(buf, enc, next) {
    min.write(buf)
    next()
  }, function end(next) {
    out.on('finish', next)
    min.end()
  })
  out.on('error', s.emit.bind(s, 'error'))
  min.pipe(out)
  return s
}
```

I found the problem is the source map browserify generated has a chartset field so `matched` is `null`

`sourceMappingURL=data:application\/json;charset:utf-8;base64`.

I modified the RegExp but it still do not work.

After reading the uglifyjs api, I though it is no need to add these code

```
var map = convert.fromJSON(min.map)
map.setProperty('sources', [file])
map.setProperty('sourcesContent', matched
  ? opts.inSourceMap.sourcesContent
  : [buffer]
)
```

I removed these code and it works well. 囧
