### PR TITLE
Allow sourcemap utf8 charset

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function uglifyify(file, opts) {
     buffer += chunk
   }, capture(function ready() {
     var matched = buffer.match(
-      // matche inlined sourcemap with or without a charset definition
+      // match an inlined sourcemap with or without a charset definition
       /\/\/[#@] ?sourceMappingURL=data:application\/json(?:;charset=utf-8)?;base64,([a-zA-Z0-9+\/]+)={0,2}\n?$/
     )
 

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function uglifyify(file, opts) {
   }, capture(function ready() {
     var matched = buffer.match(
       // matche inlined sourcemap with or without a charset definition
-      /\/\/[#@] ?sourceMappingURL=data:application\/json(;charset=utf-8)?;base64,([a-zA-Z0-9+\/]+)={0,2}\n?$/
+      /\/\/[#@] ?sourceMappingURL=data:application\/json(?:;charset=utf-8)?;base64,([a-zA-Z0-9+\/]+)={0,2}\n?$/
     )
 
     debug = opts.sourcemap !== false && (debug || matched)

--- a/index.js
+++ b/index.js
@@ -41,7 +41,8 @@ function uglifyify(file, opts) {
     buffer += chunk
   }, capture(function ready() {
     var matched = buffer.match(
-      /\/\/[#@] ?sourceMappingURL=data:application\/json;base64,([a-zA-Z0-9+\/]+)={0,2}\n?$/
+      // matche inlined sourcemap with or without a charset definition
+      /\/\/[#@] ?sourceMappingURL=data:application\/json(;charset=utf-8)?;base64,([a-zA-Z0-9+\/]+)={0,2}\n?$/
     )
 
     debug = opts.sourcemap !== false && (debug || matched)


### PR DESCRIPTION
Based on an [issue](https://github.com/garthenweb/bubleify/issues/1) on my [bubleify](https://github.com/garthenweb/bubleify) transform I had a look into your uglifyify transform and found out that it is not compatible with source maps that are defined with an utf-8 charset like buble is doing it (based on [magic-string](https://github.com/Rich-Harris/magic-string/blob/master/src/utils/SourceMap.js#L19)).

This PR allow both, source maps with mimetype `application/json;charset=utf-8` and `application/json`.