### PR TITLE
use relative source paths in sourcemaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function uglifyify(file, opts) {
     if (min.map && min.map !== 'null') {
       var map = convert.fromJSON(min.map)
 
-      map.setProperty('sources', [file])
+      map.setProperty('sources', [path.basename(file)])
       map.setProperty('sourcesContent', matched
         ? opts.inSourceMap.sourcesContent
         : [buffer]


### PR DESCRIPTION
Fixes #46 

Coffeeify made this same fix back in November.
https://github.com/jnordberg/coffeeify/commit/09a731b433b67c201e20888a18431883c6b05a5a#diff-168726dbe96b3ce427e7fedce31bb0bcR68