### PR TITLE
minimatch@^3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "convert-source-map": "~1.1.0",
     "extend": "^1.2.1",
-    "minimatch": "^2.0.7",
+    "minimatch": "^3.0.2",
     "through": "~2.3.4",
     "uglify-js": "2.x.x"
   },


### PR DESCRIPTION
Contains a fix for a RegExp DoS issue. Only breaking change between 2 and 3 was the removal of the browserified version from the published package.

Tests pass locally for me.