### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "A browserify transform which minifies your code using UglifyJS2",
   "main": "index.js",
   "dependencies": {
-    "convert-source-map": "~1.1.0",
+    "convert-source-map": "~1.3.0",
     "extend": "^1.2.1",
     "minimatch": "^2.0.7",
     "through": "~2.3.4",
-    "uglify-js": "2.x.x"
+    "uglify-js": "^2.5.x"
   },
   "devDependencies": {
     "bl": "^0.9.3",


### PR DESCRIPTION
Fixes issue where using source maps with older versions of uglify generates
tons of warnings.

Using source maps with older versions of uglify generates many (~7000 for my
SPA) warnings that look like:

```
WARN: Couldn't figure out mapping for ?:62,2 → 1,1611 []
WARN: Couldn't figure out mapping for ?:62,15 → 1,1613 []
WARN: Couldn't figure out mapping for ?:63,4 → 1,1648 []
WARN: Couldn't figure out mapping for ?:68,9 → 1,1690 []
...
```

This is due to a [bug in the `source-map` library](https://github.com/mishoo/UglifyJS2/issues/436) which is a dependency
of `uglify-js`.

Restricting `uglify-js` and `convert-source-map` to newer versions ensures that
incompatible versions of `source-map` are not installed.
