### PR TITLE
use uglify-es as the main uglify module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # uglifyify
 
 A [Browserify](http://browserify.org) v2 transform which minifies your code
-using [UglifyJS2](https://github.com/mishoo/UglifyJS2).
+using [uglify-es](https://github.com/mishoo/UglifyJS2/tree/harmony).
 
 ## Installation
 
@@ -96,9 +96,7 @@ var fs = require('fs')
 
 var bundler = browserify(__dirname + '/index.js')
 
-bundler.transform({
-  global: true
-}, 'uglifyify')
+bundler.transform('uglifyify', { global: true  })
 
 bundler.bundle()
   .pipe(fs.createWriteStream(__dirname + '/bundle.js'))
@@ -123,13 +121,13 @@ browserify -g [ uglifyify --ignore '**/node_modules/weakmap/*' ] ./index.js
 ``` javascript
 var bundler = browserify('index.js')
 
-bundler.transform({
-    global: true
-  , ignore: [
+bundler.transform('uglifyify', {
+  global: true,
+  ignore: [
       '**/node_modules/weakmap/*'
     , '**/node_modules/async/*'
   ]
-}, 'uglifyify')
+})
 
 bundler.bundle().pipe(process.stdout)
 ```
@@ -172,7 +170,7 @@ browserify -t [ uglifyify --no-sourcemap ] app.js
 ``` javascript
 var bundler = browserify('index.js')
 
-bundler.transform({ sourcemap: false }, 'uglifyify')
+bundler.transform('uglifyify', { sourceMap: false })
   .bundle()
   .pipe(process.stdout)
 ```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "extend": "^1.2.1",
     "minimatch": "^3.0.2",
     "through": "~2.3.4",
-    "uglify-js": "2.x.x"
+    "uglify-es": "^3.0.15"
   },
   "devDependencies": {
     "bl": "^0.9.3",

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 const convert    = require('convert-source-map')
 const wrap       = require('wrap-stream')
 const browserify = require('browserify')
-const uglify     = require('uglify-js')
+const uglify     = require('uglify-es')
 const from2      = require('from2')
 const test       = require('tape')
 const path       = require('path')
@@ -77,7 +77,7 @@ test('uglifyify: passes options to uglify', function(t) {
 
   fs.createReadStream(src)
     .pipe(closure())
-    .pipe(uglifyify(src, { compress: false, mangle: false }))
+    .pipe(uglifyify(src, { compress: { conditionals: false } }))
     .pipe(bl(buffered1))
 
   function buffered1(err, _buf1) {
@@ -113,8 +113,9 @@ test('uglifyify: sourcemaps', function(t) {
   var json = path.join(__dirname, 'fixture.json')
   var orig = fs.readFileSync(src, 'utf8')
   var min  = uglify.minify(orig, {
-    outSourceMap: 'out.js.map'
-    , fromString: true
+    sourceMap: {
+      url: 'out.js.map'
+    }
   })
 
   var map = convert.fromJSON(min.map)


### PR DESCRIPTION
This pull-request brings in the new version of uglify, [uglify-es](https://github.com/mishoo/UglifyJS2/tree/harmony) to help handle some ES6 syntax. 

A few things have changed since the version that was used here, mainly:
- sourceMap is now an object that has `filename`, `url`, and `content` opts to be used. `url` is used for `out.min.js`, `content` is used to distinguish what's already in the source map, and `filename` is the location of the output 
- both `mangle` and `compress` are now objects as well, and come with some reasonable defaults we can expect folks to research prior to use, otherwise uglifyify should work with what's in default
- `global` option is now deprecated
- `exts` is no longer supported, so the value is now deleted from uglifyify's `opts` prior to getting passed to `uglify`

Hope this makes sense, and let me know if you have any questions!

Thank you ^___^

(cc @toddself @yoshuawuyts)
