### PR TITLE
Make a copy of incoming options

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var minimatch = require('minimatch').Minimatch
 module.exports = uglifyify
 
 function uglifyify(file, opts) {
-  opts = opts || {}
+  opts = extend(true, {}, opts);
 
   var debug = '_flags' in opts
     ? opts._flags.debug

--- a/test/index.js
+++ b/test/index.js
@@ -45,6 +45,7 @@ test('uglifyify: ignores json', function(t) {
 test('uglifyify: -t [ uglifyify --exts ]', function(t) {
   var src  = path.join(__dirname, 'fixture.js')
   var orig = fs.readFileSync(src, 'utf8')
+  var options = { exts: ['mkdn' ], x: ['.obj2'] };
 
   t.plan(5)
 
@@ -56,7 +57,7 @@ test('uglifyify: -t [ uglifyify --exts ]', function(t) {
 
   function check(name, ignored) {
     fs.createReadStream(src)
-      .pipe(uglifyify(name, { exts: ['mkdn' ], x: ['.obj2'] }))
+      .pipe(uglifyify(name, options))
       .pipe(bl(buffered))
 
     function buffered(err, data) {


### PR DESCRIPTION
Options need to be copied since some properties are later deleted from the referenced object in Uglifyify. If copying does not occur, and the `opts` object is coming from an assigned variable, that object will be mutated with the deleted properties and any subsequent Uglifyify calls will not have the needed deleted properties – i.e. `exts`, `x`, `global`. 

The test is modified to show this case.