### PR TITLE
Fix github security warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,12 @@ var minimatch = require('minimatch').Minimatch
   , through = require('through')
   , path = require('path')
   , ujs = require('terser')
-  , extend = require('extend')
+  , xtend = require('xtend')
 
 module.exports = uglifyify
 
 function uglifyify(file, opts) {
-  opts = opts || {}
+  opts = xtend(opts || {})
 
   var debug = opts._flags && opts._flags.debug
 
@@ -42,7 +42,7 @@ function uglifyify(file, opts) {
     buffer += chunk
   }, capture(function ready() {
     debug = opts.sourceMap !== false && debug
-    opts  = extend({}, {
+    opts  = xtend({
       compress: true,
       mangle: true,
       sourceMap: {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "dependencies": {
     "convert-source-map": "~1.1.0",
-    "extend": "^1.2.1",
     "minimatch": "^3.0.2",
     "terser": "^3.7.5",
-    "through": "~2.3.4"
+    "through": "~2.3.4",
+    "xtend": "^4.0.1"
   },
   "devDependencies": {
     "bl": "^0.9.3",


### PR DESCRIPTION
use xtend, already common in browserify installs