### PR TITLE
update terser version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "convert-source-map": "~1.1.0",
     "extend": "^1.2.1",
     "minimatch": "^3.0.2",
-    "terser": "^3.7.5",
+    "terser": "^4.0.0",
     "through": "~2.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Terser 4.x does not break compatibility with Terser 3, given this library does not expose the raw Terser/Uglify AST to its users.

Just making sure you don't fall behind :)

Cheers!