### PR TITLE
ES5 compatible

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var minimatch = require('minimatch').Minimatch
   , convert = require('convert-source-map')
   , through = require('through')
   , path = require('path')
-  , ujs = require('terser')
+  , terser = require('terser')
   , xtend = require('xtend')
 
 module.exports = uglifyify
@@ -11,6 +11,7 @@ function uglifyify(file, opts) {
   opts = xtend(opts || {})
 
   var debug = opts._flags && opts._flags.debug
+  var ujs = opts.uglify || terser
 
   if (ignore(file, opts.ignore)) {
     return through()

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "convert-source-map": "~1.1.0",
     "minimatch": "^3.0.2",
-    "terser": "^3.7.5",
+    "terser": "3.16.1",
     "through": "~2.3.4",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
terser introduced ES2015 syntax in a minor release, breaking support for Node.js versions older than v6. This pins it to the last terser release that worked on older Node.js versions, and adds an option to allow users to pass in their own uglify-compatible module.

#96 could be done in a major release after this one.